### PR TITLE
Delete call does not use value

### DIFF
--- a/mct-dapp-template.py
+++ b/mct-dapp-template.py
@@ -134,7 +134,7 @@ def handle_token_received(chash, args):
 def Get(key):
     return MCTContract('Get', [key])
 
-def Delete(key, value):
+def Delete(key):
     return MCTContract('Delete', [key]) 
 
 def Put(key, value):


### PR DESCRIPTION
This change just removed a likely copy pasta fail. Delete() should not be called with value. See line 120 for call to Delete() only passing key. This simply corrects this definition. 