### PR TITLE
Example usage calling external script in C#

### DIFF
--- a/mct_dapp_example.cs
+++ b/mct_dapp_example.cs
@@ -1,0 +1,60 @@
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Services.Neo;
+using Neo.SmartContract.Framework.Services.System;
+using System;
+using System.ComponentModel;
+using System.Numerics;
+
+namespace Neo.SmartContract
+{
+	public class Mct_Dapp_Example : Framework.SmartContract
+	{
+		public delegate object NEP5Contract(string method, object[] args);
+		
+		//MainNet
+		//[AppCall("a87cc2a513f5d8b4a42432343687c2127c60bc3f".ToScriptHash())]
+		//public static extern int MCTContract (string operation, object[] args);
+
+		//TestNet
+		[AppCall("c186bcb4dc6db8e08be09191c6173456144c4b8d".ToScriptHash())] // ScriptHash
+		public static extern int MCTContract (string operation, object[] args);
+
+		public static void Main (string operation, params object[] args)
+		{
+			switch (operation)
+			{
+				case "Put":
+					return put_mct((object)args);
+				case "Get":
+					return get_mct((object)args);
+				case "Delete":
+					return delete_mct((object)args);
+				default:
+					return false;
+			}
+		}
+
+		private static bool put_mct(object[] data)
+		{
+			if (!Runtime.CheckWitness(owner)) return false;
+			byte[] value = get_mct((object)data[0]);
+			if (value != null) return false;
+      
+			return MCTContract("Put", data);
+		}
+
+		private static byte[] get_mct(object[] key)
+		{
+			return MCTContract("Get", key);
+		}
+
+		private static bool delete_mct(object[] key)
+		{
+			byte[] owner = get_mct(key);
+			if (owner == null) return false;
+			if (!Runtime.CheckWitness(owner)) return false;
+      
+			return MCTContract("Delete", key);
+		}
+	}
+}


### PR DESCRIPTION
This is an example of how you would invoke the MCT storage available to a contract. 
Things to note:
- Line 15 and 19 the `"".ToScriptHash()` call should work, but could be replaced with the actual ScriptHash instead.
- The object that is being sent to all the different MCT calls may need to be wrapped such that it is not sending just the raw object but either a single or two item array along with the operation.
- The Type for `get_mct` may also need to be adjusted if it just returns the key:value pair and not just value, if that is the case the type would likely be `object[]`. Would also require change for value and owner checks. 
- Format for example was taken from here http://docs.neo.org/en-us/sc/tutorial/Domain.html and here http://docs.neo.org/en-us/sc/quickstart/call.html