### PR TITLE
Remove un-needed return

### DIFF
--- a/mct-dapp-template.py
+++ b/mct-dapp-template.py
@@ -53,8 +53,6 @@ def Main(operation, args):
                 return True
             print('staked storage call failed')
             return False
-
-            return True
          
         if operation == 'ownerWithdraw':
             if not CheckWitness(OWNER):


### PR DESCRIPTION
There was an additional `return True` at the end of `hello` operation. Would probably cause weird behavior if call to storage were to fail.